### PR TITLE
Add CMake as an alternative build scaffold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,152 @@
+cmake_minimum_required(VERSION 3.15...3.21 FATAL_ERROR)
+
+# -- project setup -------------------------------------------------------------
+
+project(
+  libfilter
+  VERSION 0.1.0
+  DESCRIPTION "High-speed Bloom filters and taffy filters for C and C++"
+  HOMEPAGE_URL "https://github.com/tenzir/libfilter"
+  LANGUAGES C CXX)
+
+# -- sanity checks -------------------------------------------------------------
+
+# Prohibit in-source builds.
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+  message(FATAL_ERROR "In-source builds are not allowed.")
+endif ()
+
+# Ensure that CMAKE_INSTALL_PREFIX is not a relative path.
+if (NOT IS_ABSOLUTE "${CMAKE_INSTALL_PREFIX}")
+  message(
+    FATAL_ERROR
+      "CMAKE_INSTALL_PREFIX must be an absolute path: ${CMAKE_INSTALL_PREFIX}")
+endif ()
+
+# -- includes ------------------------------------------------------------------
+
+include(CMakePackageConfigHelpers)
+include(CMakePrintHelpers)
+include(GNUInstallDirs)
+
+# -- project configuration -----------------------------------------------------
+
+# Determine whether we're building libfilter as a subproject. This is used to
+# determine good default values for many options. libfilter should not modify
+# global CMake if built as a subproject, unless explicitly requested to do so
+# with options.
+get_directory_property(_libfilter_PARENT_DIRECTORY PARENT_DIRECTORY)
+if (_libfilter_PARENT_DIRECTORY)
+  set(libfilter_IS_SUBPROJECT ON)
+  set(libfilter_IS_NOT_SUBPROJECT OFF)
+else ()
+  set(libfilter_IS_SUBPROJECT OFF)
+  set(libfilter_IS_NOT_SUBPROJECT ON)
+endif ()
+unset(_libfilter_PARENT_DIRECTORY)
+
+# -- internal target -----------------------------------------------------------
+
+# Create the internal target that is used for option/property propagation.
+add_library(libfilter_internal INTERFACE)
+set_target_properties(libfilter_internal PROPERTIES EXPORT_NAME internal)
+add_library(libfilter::internal ALIAS libfilter_internal)
+install(TARGETS libfilter_internal EXPORT libfilterTargets)
+
+# Require standard C++20.
+target_compile_features(libfilter_internal INTERFACE cxx_std_20)
+
+# Increase maximum number of template instantiations.
+target_compile_options(libfilter_internal INTERFACE
+  $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang,GCC>:-ftemplate-backtrace-limit=0>)
+
+# -- FreeBSD support -----------------------------------------------------------
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  # Works around issues with libstdc++ and C++11. For details, see: -
+  # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=194929 -
+  # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=182657
+  target_compile_definitions(
+    libfilter_internal INTERFACE _GLIBCXX_USE_C99 _GLIBCXX_USE_C99_MATH
+                                 _GLIBCXX_USE_C99_MATH_TR1)
+endif ()
+
+# -- compile options -----------------------------------------------------------
+
+target_compile_options(
+  libfilter_internal
+  INTERFACE $<$<CONFIG:Release>:-fno-omit-frame-pointer>
+            $<$<CONFIG:RelWithDebInfo>:-fno-omit-frame-pointer>
+            $<$<CONFIG:Debug>:-O0>
+            -msse3 -mssse3 -msse4.1 -msse4.2 -mavx -mavx2 -mfma)
+
+# -- developer mode ------------------------------------------------------------
+
+# Build libfilter in developer mode. This is enabled by default when not building
+# libfilter as a subproject. The developer mode contains CCache support and many
+# other niceties.
+option(libfilter_ENABLE_DEVELOPER_MODE
+       "Enables build settings for a nicer development environment"
+       "${libfilter_IS_NOT_SUBPROJECT}")
+
+if (libfilter_ENABLE_DEVELOPER_MODE)
+  # Support tools like clang-tidy by creating a compilation database and
+  # copying it to the project root.
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+  # Force colored output for the Ninja generator
+  if ("${CMAKE_GENERATOR}" MATCHES "Ninja")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      target_compile_options(libfilter_internal
+                             INTERFACE -fdiagnostics-color=always)
+    elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+      target_compile_options(libfilter_internal INTERFACE -fcolor-diagnostics)
+    endif ()
+  endif ()
+
+  # Keep make output sane
+  set(CMAKE_VERBOSE_MAKEFILE
+      OFF
+      CACHE STRING "Show all outputs including compiler lines." FORCE)
+endif ()
+
+if (libfilter_ENABLE_DEVELOPER_MODE OR libfilter_ENABLE_BUILDID)
+  # Relocate debug paths to a common prefix for CCache users that work from
+  # multiple worktrees.
+  # The debug paths affect the build-id, we rewrite them to get a more
+  # reproducible build.
+  target_compile_options(
+    libfilter_internal
+    INTERFACE "-fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
+endif ()
+
+
+add_subdirectory(c)
+add_subdirectory(cpp)
+
+# -- cmake export/config installations -----------------------------------------
+
+export(
+  EXPORT libfilterTargets
+  FILE libfilterTargets.cmake
+  NAMESPACE libfilter::)
+
+install(
+  EXPORT libfilterTargets
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libfilter"
+  NAMESPACE libfilter::)
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/libfilterConfigVersion.cmake"
+  VERSION "${libfilter_VERSION_MAJOR}.${libfilter_VERSION_MINOR}.${libfilter_VERSION_PATCH}"
+  COMPATIBILITY ExactVersion)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/libfilterConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/libfilterConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libfilter")
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/libfilterConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/libfilterConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libfilter")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(
   libfilter
   VERSION 0.1.0
   DESCRIPTION "High-speed Bloom filters and taffy filters for C and C++"
-  HOMEPAGE_URL "https://github.com/tenzir/libfilter"
+  HOMEPAGE_URL "https://github.com/jbapple/libfilter"
   LANGUAGES C CXX)
 
 # -- sanity checks -------------------------------------------------------------
@@ -54,31 +54,7 @@ add_library(libfilter::internal ALIAS libfilter_internal)
 install(TARGETS libfilter_internal EXPORT libfilterTargets)
 
 # Require standard C++20.
-target_compile_features(libfilter_internal INTERFACE cxx_std_20)
-
-# Increase maximum number of template instantiations.
-target_compile_options(libfilter_internal INTERFACE
-  $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang,GCC>:-ftemplate-backtrace-limit=0>)
-
-# -- FreeBSD support -----------------------------------------------------------
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  # Works around issues with libstdc++ and C++11. For details, see: -
-  # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=194929 -
-  # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=182657
-  target_compile_definitions(
-    libfilter_internal INTERFACE _GLIBCXX_USE_C99 _GLIBCXX_USE_C99_MATH
-                                 _GLIBCXX_USE_C99_MATH_TR1)
-endif ()
-
-# -- compile options -----------------------------------------------------------
-
-target_compile_options(
-  libfilter_internal
-  INTERFACE $<$<CONFIG:Release>:-fno-omit-frame-pointer>
-            $<$<CONFIG:RelWithDebInfo>:-fno-omit-frame-pointer>
-            $<$<CONFIG:Debug>:-O0>
-            -msse3 -mssse3 -msse4.1 -msse4.2 -mavx -mavx2 -mfma)
+target_compile_features(libfilter_internal INTERFACE cxx_std_14)
 
 # -- developer mode ------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ mvn -f ./java/ install -Dmaven.test.skip=true
 [optional: copy java/target/libfilter-*.jar to your classpath]
 ```
 
+The C and C++ libraries can also be installed with CMake:
+```shell
+cmake -B build -S . -DCMAKE_INSTALL_PATH=<where/to/install>
+cmake --build build
+# probably needs a sudo:
+cmake --install build
+```
+
+The library targets are exported and can be used in `CMakeLists.txt`:
+```cmake
+find_package(libfilter)
+# The C API:
+target_link_libraries(mylib PRIVATE libfilter::c)
+# The C++ API:
+target_link_libraries(mylib PRIVATE libfilter::cxx)
+```
+
 Block filters are most space-efficient at around 11.5 bits per
 distinct value, which produces a false positive probability of
 0.65%. A traditional Bloom filter would only need 10.5 bits per

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,0 +1,31 @@
+set(sources
+  lib/block.c
+  lib/memory.c
+  lib/util.c)
+
+add_library(libfilter_c ${sources})
+add_library(libfilter::c ALIAS libfilter_c)
+
+target_link_libraries(libfilter_c PRIVATE libfilter_internal)
+
+target_include_directories(
+  libfilter_c
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_target_properties(libfilter_c PROPERTIES EXPORT_NAME c
+                                             OUTPUT_NAME filter)
+
+# Install libfilter_c in PREFIX/lib and headers in PREFIX/include/filter.
+install(
+  TARGETS libfilter_c
+  EXPORT libfilterTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(
+  DIRECTORY include/filter
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING
+  PATTERN "*.h")

--- a/cmake/libfilterConfig.cmake.in
+++ b/cmake/libfilterConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libfilterTargets.cmake")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_library(libfilter_cxx INTERFACE)
+add_library(libfilter::cxx ALIAS libfilter_cxx)
+
+target_link_libraries(libfilter_cxx INTERFACE libfilter_internal)
+target_link_libraries(libfilter_cxx INTERFACE libfilter_c)
+
+target_include_directories(
+  libfilter_cxx
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_target_properties(libfilter_cxx PROPERTIES EXPORT_NAME cxx)
+
+# Install libfilter_c in PREFIX/lib and headers in PREFIX/include/filter.
+install(
+  TARGETS libfilter_cxx
+  EXPORT libfilterTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(
+  DIRECTORY include/filter
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING
+  PATTERN "*.hpp")


### PR DESCRIPTION
Same [PR as upstream](https://github.com/jbapple/libfilter/pull/2), but we don't know whether the contribution will get accepted.

---

The project can now be built with
```
cmake -Bbuild -S . -DCMAKE_PREFIX_PATH=<your/install/location>
cmake --build build
cmake --install install # <- use sudo if the current user doesn't have write permissions for <your/install/location>
```

One can also import the CMake targets into other projects with `find_package(libfilter)`.
One should then be able to link with the `libfilter::c` and `libfilter::cxx` targets.

The scaffolding is done so one can use `find_package(libfilter)` or `add_subdirectory(libfilter)` interchangeably.